### PR TITLE
VIT-777 add with_stream param to sleep GET

### DIFF
--- a/client/Sleep.ts
+++ b/client/Sleep.ts
@@ -17,12 +17,13 @@ export class SleepApi {
     userId: string,
     startDate: Date,
     endDate?: Date,
-    provider?: string
+    provider?: string,
+    with_stream?: boolean
   ): Promise<ClientSleepResponse> {
     const resp = await this.client.get(
       this.baseURL.concat(`/summary/sleep/${userId}`),
       {
-        params: { start_date: startDate, end_date: endDate, provider },
+        params: { start_date: startDate, end_date: endDate, provider, with_stream },
       }
     );
     return resp.data;

--- a/client/Sleep.ts
+++ b/client/Sleep.ts
@@ -18,7 +18,7 @@ export class SleepApi {
     startDate: Date,
     endDate?: Date,
     provider?: string,
-    with_stream?: boolean
+    with_stream: boolean = false
   ): Promise<ClientSleepResponse> {
     const resp = await this.client.get(
       this.baseURL.concat(`/summary/sleep/${userId}`),


### PR DESCRIPTION
* sleep GET requests are missing sleep_stream. The with_stream boolean param determines if we want to retrieve sleep_stream data along with sleep data.