### PR TITLE
VIT-1191 add region api parameter

### DIFF
--- a/client/Link.ts
+++ b/client/Link.ts
@@ -49,12 +49,14 @@ export class LinkApi {
   public async connectEmailProvider(
     linkToken: string,
     provider: EmailProviders,
-    email: string
+    email: string,
+    region?: string,
   ): Promise<ProviderLinkResponse> {
     const resp = await this.client.post(
       this.baseURL.concat(`/link/provider/email/${provider}`),
       {
         email,
+        region: region || null
       },
       { headers: { LinkToken: linkToken } }
     );


### PR DESCRIPTION
CI is failing because our GitHub secrets are likely pointing to a user that doesn't exist anymore... That and the fact that we don't use client_id and client_secret anymore means that this relatively trivial change will require a lot more to get the tests passing. I vote for moving this to this ticket

[VIT-1214](https://linear.app/try-vital/issue/VIT-1214/fix-vital-python-and-vital-node-ci)