### PR TITLE
[VIT-2360] Rewrite the implementation of getSleepWithStream

### DIFF
--- a/client/Sleep.ts
+++ b/client/Sleep.ts
@@ -1,13 +1,16 @@
 import { AxiosInstance } from 'axios';
+
 import {
   ClientSleepResponse,
   ClientSleepStreamResponse,
 } from './models/sleep_models';
 import { ClientSleepRawResponse } from './models/raw_response';
+import { utils } from './lib/utils';
 
 export class SleepApi {
   baseURL: string;
   client: AxiosInstance;
+
   constructor(baseURL: string, axios: AxiosInstance) {
     this.baseURL = baseURL;
     this.client = axios;
@@ -35,12 +38,23 @@ export class SleepApi {
     endDate?: Date,
     provider?: string
   ): Promise<ClientSleepResponse> {
+    if (utils.getDayDiff(startDate, endDate) > 7) {
+      console.warn('WARNING: calling getSleepWithStream for more than 7 days can significantly increase the latency of the request. Please consider reducing the number of days requested.');
+    }
+
     const resp = await this.client.get(
-      this.baseURL.concat(`/summary/sleep/${userId}/stream`),
+      this.baseURL.concat(`/summary/sleep/${userId}`),
       {
         params: { start_date: startDate, end_date: endDate, provider },
       }
     );
+
+    let response = resp.data as ClientSleepResponse;
+    for (let i = 0; i < response.sleep.length; i++) {
+      const stream = await this.getStream(response.sleep[i].id);
+      response.sleep[i].sleep_stream = [stream];
+    }
+
     return resp.data;
   }
 

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -31,4 +31,17 @@ export const utils = {
     }
     return result === 0;
   },
+
+  // Get the difference in days between two dates.
+  getDayDiff: (startDate: Date, endDate?: Date): number => {
+    if (!endDate) {
+      endDate = new Date();
+    }
+
+    const msInDay = 24 * 60 * 60 * 1000;
+
+    return Math.round(
+      Math.abs(endDate.getTime() - startDate.getTime()) / msInDay,
+    );
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryvital/vital-node",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Node client for Vital",
   "author": "maitham",
   "keywords": [


### PR DESCRIPTION
Do not use the `/summary/sleep/{user_id}/stream` endpoint anymore (soon to be deprecated), but instead fetch the sleep summaries first, and do a separate call to `/timeseries/sleep/{sleep_id}/stream`  for each one of them.

Also, add a warning if the date range is >7 days.

I only changed the minor version because no method signature changed, just the implementation.