### PR TITLE
[VIT-3807] Add payor and diagnosis search methods

### DIFF
--- a/client/LabTests.ts
+++ b/client/LabTests.ts
@@ -2,14 +2,14 @@ import { AxiosInstance } from 'axios';
 import {
   AreaInfo,
   ClientFacingLabTest,
-  Consent,
+  Consent, Diagnosis,
   HealthInsurance,
   LabResultsMetadata,
   LabResultsResponse,
   Order,
   OrderRequestResponse,
   PatientAdress,
-  PatientDetails,
+  PatientDetails, Payor,
   Physician,
   ShippingDetails,
 } from './models/lab_tests_model';
@@ -96,6 +96,25 @@ export class OrdersApi {
   public async getOrder(orderId: string): Promise<Order> {
     const resp = await this.client.get(
       this.baseURL.concat(`/order/${orderId}`)
+    );
+    return resp.data;
+  }
+
+  //Get order status.
+  public async searchPayor(insurance_name: string, insurance_state?: string): Promise<Payor> {
+    const resp = await this.client.post(
+      this.baseURL.concat(`/insurance/search/payor`), {
+          insurance_name: insurance_name,
+          insurance_state: insurance_state ?? null
+        }
+    );
+    return resp.data;
+  }
+
+  public async searchDiagnosis(diagnosis_query: string): Promise<Diagnosis[]> {
+    const resp = await this.client.get(
+      this.baseURL.concat('/insurance/search/diagnosis?') +
+        new URLSearchParams({ diagnosis_query: diagnosis_query })
     );
     return resp.data;
   }

--- a/client/models/lab_tests_model.ts
+++ b/client/models/lab_tests_model.ts
@@ -1,3 +1,5 @@
+import {USAddress} from "./athome_phlebotomy_models";
+
 export type ConsentType = "terms-of-use" | "telehealth-informed-consent" | "mobile-terms-and-conditions" | "notice-of-privacy-practices" | "privacy-policy" | "hipaa-authorization";
 
 export type Consent = {
@@ -69,6 +71,25 @@ export interface TestkitEvent {
   id: number;
   created_at: string;
   status: string;
+}
+
+export interface PayorAddress{
+  city: string;
+  state: string;
+  zip: string;
+  country: string;
+  first_line: string;
+}
+
+export interface Payor {
+  code: string;
+  name: string;
+  org_address: PayorAddress;
+}
+
+export interface Diagnosis {
+  diagnosis_code: string;
+  description: string;
 }
 
 export interface Order {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryvital/vital-node",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Node client for Vital",
   "author": "maitham",
   "keywords": [


### PR DESCRIPTION
## Description

Add the new search routes for Payor and Diagnosis, to have a more seamless experience when placing insurance orders with Labcorp while using the SDK.