### PR TITLE
[VIT-4601] Update providers in the node client

### DIFF
--- a/client/models/link_models.ts
+++ b/client/models/link_models.ts
@@ -1,11 +1,26 @@
-export type PasswordProviders = 'whoop' | 'renpho' | 'peloton' | 'zwift' | 'hammerhead';
+export type PasswordProviders =
+  | 'whoop'
+  | 'renpho'
+  | 'peloton'
+  | 'zwift'
+  | 'hammerhead'
+  | 'eight_sleep'
+  | 'beurer_api'
+  | 'dexcom'
+  | 'my_fitness_pal';
+
 export type OAuthProviders =
   | 'oura'
   | 'fitbit'
   | 'garmin'
-  | 'whoop'
   | 'strava'
-  | 'wahoo';
+  | 'wahoo'
+  | 'ihealth'
+  | 'withings'
+  | 'google_fit'
+  | 'dexcom_v3'
+  | 'polar'
+  | 'cronometer';
 
 export type EmailProviders = 'freestyle_libre';
 export type DemoProviders = 'apple_health_kit' | 'fitbit' | 'oura' | 'whoop';


### PR DESCRIPTION
Updated the node providers to be in sync with https://github.com/tryVital/vital-mono/blob/main/vital-background-pull/vital_core/schemas/providers.py